### PR TITLE
Fixing invalid repo URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the plugin in ```~/.zazurc.json``` file:
 ```json
 {
   "plugins": [
-    "brpaz/encode-decode",
+    "brpaz/zazu-encode-decode",
   ]
 }
 ```


### PR DESCRIPTION
The rc example has an invalid URL to the repository